### PR TITLE
feat: add database observability module

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The following modules are available:
 - [Notifications](./notifications/)
 - [Streams](./streams/)
 - [Service Connectors](./service-connectors/)
+- [Database Observability](./database-observability/)
 
 Within each module you find an *examples* folder. Each example is a fully runnable Terraform configuration that you can quickly test and put to use by modifying the input data according to your own needs.  
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,3 +1,14 @@
+# Unreleased
+
+## Updates
+1. [Database Observability module](./database-observability/)
+  - Enhancement: Added Vault-backed Database Management and Operations Insights
+    lifecycle management for Base Database Service and Exadata Database Service
+    CDB, PDB, and non-CDB targets. Includes Landing Zone dependency maps,
+    staged fail-closed disablement, private endpoints, examples, JSON Schema,
+    and One-OE source configuration fragments. Tracks
+    [issue 33](https://github.com/oci-landing-zones/terraform-oci-modules-observability/issues/33).
+
 # May 14, 2026 Release Notes - 0.2.6
 
 ## Updates

--- a/database-observability/MIGRATION.md
+++ b/database-observability/MIGRATION.md
@@ -1,0 +1,49 @@
+# Migration to the Landing Zone database-observability module
+
+This module changes both the public input contract and several Terraform
+resource addresses from `terraform/modules/dbm-opsi-enablement`. Treat the
+migration as a production state migration, not a normal module-source update.
+
+## Before migration
+
+1. Pin the currently deployed source and OCI provider.
+2. Record the current resource addresses with a metadata-only state listing.
+3. Back up the encrypted remote state through the state owner's approved
+   recovery process.
+4. Prove the migration in a non-production or canary compartment.
+5. Populate the Landing Zone configuration object with the same target keys,
+   database identities, endpoint identities, and Vault secret references.
+
+## Address mapping
+
+The common address changes are:
+
+| Previous module resource | New module resource |
+| --- | --- |
+| `oci_database_management_database_dbm_features_management.dbm_cdb` | `oci_database_management_database_dbm_features_management.cdb` |
+| `oci_database_management_database_dbm_features_management.dbm_standalone` | `oci_database_management_database_dbm_features_management.non_cdb` |
+| `oci_opsi_database_insight.insight` | `oci_opsi_database_insight.these` |
+
+Use reviewed `moved` blocks in the calling root when the source and destination
+resource schemas are identical. Retain those blocks for supported upgrade
+paths.
+
+PDBs require special handling. The earlier module addressed PDBs through
+`oci_database_management_database_dbm_features_management`; this module uses
+the provider's PDB-specific
+`oci_database_management_pluggabledatabase_pluggable_database_dbm_features_management`.
+Do not assume Terraform can move state between those resource types. Use a
+reviewed declarative import into the new PDB address, remove the old address
+only through the approved state-migration process, and require a refreshed plan
+with no unintended disable, replacement, or enable action.
+
+## Acceptance
+
+The migration is accepted only when:
+
+- every remote object has exactly one Terraform address;
+- the refreshed plan contains no unintended create, delete, or replacement;
+- CDB/PDB ordering remains explicit;
+- current DBM and Operations Insights collection is verified after apply; and
+- the prior state backup can be restored according to the tested recovery
+  procedure.

--- a/database-observability/README.md
+++ b/database-observability/README.md
@@ -1,0 +1,245 @@
+# OCI Landing Zone Database Observability Module
+
+![Landing Zone logo](../landing_zone_300.png)
+
+This module manages production-oriented Oracle Database observability resources
+in Oracle Cloud Infrastructure (OCI) from one configuration object. It creates
+or consumes private endpoints, enables Database Management for Base Database
+Service and Exadata Database Service CDBs, PDBs, and non-CDBs, and optionally
+enables Operations Insights.
+
+The module is structured for publication in the
+[OCI Landing Zone Observability Modules](https://github.com/oci-landing-zones/terraform-oci-modules-observability)
+repository. It follows that repository's dependency-key convention: each input
+ending in `_id` can be a literal OCID or a key in the matching dependency map.
+
+Check the [module specification](./SPEC.md) for the complete input, resource,
+and output contract. Check the [examples](./examples/) folder for Base Database
+and Exadata Database Service configurations, including JSON variable files.
+The [One-OE blueprint fragments](./blueprints/one-oe/) provide source JSON for
+the Operating Entities composition workflow.
+
+- [Requirements](#requirements)
+- [How to Invoke the Module](#invoke)
+- [Module Functioning](#functioning)
+- [Production Lifecycle](#lifecycle)
+- [External Dependencies](#dependencies)
+- [Related Documentation](#related)
+- [Known Issues](#issues)
+
+## <a name="requirements">Requirements</a>
+
+### Terraform and OCI provider
+
+- Terraform `>= 1.5.0, < 2.0.0`
+- OCI provider `>= 6.0.0, < 9.0.0`
+
+The provider is not configured inside the module. Authentication is inherited
+from the calling stack, allowing OCI Resource Manager, workload principals,
+instance principals, security tokens, or a reviewed local profile.
+
+### Existing database prerequisites
+
+- A supported Base Database Service or Exadata Database Service CDB, PDB, or
+  non-CDB.
+- A private subnet that can reach every selected database listener.
+- A Vault secret containing each monitoring-user password. Plaintext passwords
+  are not accepted.
+- A monitoring user with the grants required by the selected Database
+  Management level and Operations Insights.
+- PDB targets must reference an `ADVANCED` CDB target in the same configuration.
+
+### IAM permissions
+
+Use least-privilege policies scoped to the compartments and resource principals
+that own the deployment. The exact policy names and scopes depend on whether
+private endpoints and Vault secrets are created or consumed. A typical policy
+review includes permissions to:
+
+```text
+Allow group <terraform-operators> to manage db-management-family in compartment <database-compartment>
+Allow group <terraform-operators> to manage opsi-family in compartment <database-compartment>
+Allow group <terraform-operators> to read virtual-network-family in compartment <network-compartment>
+Allow group <terraform-operators> to read secret-family in compartment <vault-compartment>
+```
+
+The Database Management service principal also needs permission to read the
+selected Vault secrets. Do not copy these illustrative policies unchanged;
+review the current OCI IAM policy reference and separate Terraform operator,
+service-principal, and database-administrator duties.
+
+## <a name="invoke">How to Invoke the Module</a>
+
+For local development in this repository:
+
+```hcl
+module "database_observability" {
+  source = "../../database-observability"
+
+  database_observability_configuration = var.database_observability_configuration
+  compartments_dependency              = module.landing_zone_compartments.compartments
+  vcns_dependency                      = module.landing_zone_network.vcns
+  subnets_dependency                   = module.landing_zone_network.subnets
+  databases_dependency                 = module.database_platform.databases
+  vault_secrets_dependency             = module.database_secrets.secrets
+}
+```
+
+After publication in the OCI Landing Zone Observability repository, pin a
+reviewed release:
+
+```hcl
+module "database_observability" {
+  source = "github.com/oci-landing-zones/terraform-oci-modules-observability//database-observability?ref=<REVIEWED_RELEASE>"
+
+  database_observability_configuration = var.database_observability_configuration
+}
+```
+
+Never deploy an unreviewed branch or moving default branch in production.
+
+## <a name="functioning">Module Functioning</a>
+
+The `database_observability_configuration` object has these top-level
+attributes:
+
+- `default_compartment_id`: literal compartment OCID, Landing Zone compartment
+  key, or `TENANCY-ROOT` when `tenancy_ocid` is provided.
+- `default_defined_tags` and `default_freeform_tags`: tags inherited by
+  module-created resources.
+- `lifecycle_id`: stable 8-64 character ownership identifier.
+- `operation_stage`: `ENABLE`, `DISABLE_TARGETS`, or `DISABLE_CDB`.
+- `dbm_private_endpoints`: optional Database Management private endpoints
+  created by this module.
+- `opsi_private_endpoints`: optional Operations Insights private endpoints
+  created by this module.
+- `databases`: stable map of reviewed database targets.
+
+Every database key becomes part of the Terraform resource address. Do not
+rename keys after deployment without a reviewed migration.
+
+### Database targets
+
+Supported `database_type` values are:
+
+| Value | OCI target | Terraform resource |
+| --- | --- | --- |
+| `CDB` | Base Database or Exadata container database | `oci_database_management_database_dbm_features_management` |
+| `PDB` | Base Database or Exadata pluggable database | `oci_database_management_pluggabledatabase_pluggable_database_dbm_features_management` |
+| `NON_CDB` | Base Database or Exadata non-container database | `oci_database_management_database_dbm_features_management` |
+
+Each target supplies a database identifier, a Database Management private
+endpoint, listener service, and Vault secret reference. Operations Insights is
+opt-in per target and requires an Operations Insights private endpoint.
+
+Autonomous Database and external-database lifecycle APIs have different
+ownership and provider contracts. They are deliberately not represented as
+these cloud-database resources. Use the companion `dbman-opsi` lifecycle for
+those families until a separately tested Landing Zone module contract is
+published.
+
+### Private endpoints
+
+Private endpoints can be:
+
+- created in `dbm_private_endpoints` or `opsi_private_endpoints`;
+- consumed through the matching dependency map; or
+- supplied as literal OCIDs.
+
+Production callers should normally pass VCN, subnet, NSG, compartment, database,
+and Vault outputs from their owning Landing Zone modules. This module does not
+create a VCN, subnet, Vault, secret, database, database user, or broad IAM
+policy.
+
+### Operations Insights
+
+`enable_operations_insights = true` creates an
+`oci_opsi_database_insight` after Database Management enablement. Credentials
+remain Vault-backed. Registration is not collection proof; post-apply
+verification must confirm current metrics and insight data.
+
+## <a name="lifecycle">Production Lifecycle</a>
+
+### Enable
+
+Keep the default `operation_stage = "ENABLE"`. CDB resources have an explicit
+graph dependency before PDB resources. The module never uses
+`can_disable_all_pdbs` or auto-enables unreviewed PDBs.
+
+### Disable
+
+CDB/PDB disablement is intentionally two-stage:
+
+1. Set `operation_stage = "DISABLE_TARGETS"`, create and review a new plan, then
+   apply it. Operations Insights resources are removed first; PDBs and non-CDBs
+   are disabled while CDBs remain enabled.
+2. Confirm target collection has stopped. Set
+   `operation_stage = "DISABLE_CDB"`, create a new plan, and review it.
+3. The second plan reads every PDB through the current OCI provider data source.
+   It fails unless each `DIAGNOSTICS_AND_MANAGEMENT` feature is absent,
+   `DISABLED`, or `NOT_ENABLED`.
+4. Apply only that unchanged reviewed plan.
+
+No local receipt, copied output, or configuration flag can bypass the second
+plan's provider-backed observation.
+
+For a CDB-only target set, there is no child PDB state to verify. A new reviewed
+`DISABLE_CDB` plan can therefore disable the CDB directly.
+
+### Destroy and rollback
+
+A normal `terraform destroy` is not the staged disable workflow. For a managed
+fleet, first disable Operations Insights and Database Management through
+reviewed normal plans, then destroy private endpoints only after dependency and
+network checks. Reused dependencies are never owned or deleted by this module.
+
+For upgrades from this repository's earlier module, follow
+[MIGRATION.md](./MIGRATION.md). Test provider and module upgrades in a canary
+compartment and retain encrypted state backups according to the state owner's
+recovery policy.
+
+## <a name="dependencies">External Dependencies</a>
+
+The module supports these dependency maps:
+
+- `compartments_dependency`
+- `vcns_dependency`
+- `subnets_dependency`
+- `network_security_groups_dependency`
+- `databases_dependency`
+- `managed_databases_dependency`
+- `vault_secrets_dependency`
+- `dbm_private_endpoints_dependency`
+- `opsi_private_endpoints_dependency`
+
+Every map value must contain an `id` attribute. Dependency keys keep Landing
+Zone JSON configuration portable and allow producing modules to pass outputs
+without copying OCIDs between stacks.
+
+## Security and state
+
+- No variable accepts a plaintext password, private key, wallet content, or
+  database host address.
+- Vault secret OCIDs are still sensitive topology. Terraform state can contain
+  them even when display is suppressed.
+- Use an encrypted remote backend with restricted access, tested concurrency
+  controls, state recovery, and one Terraform owner.
+- Review plans for replacement, deletion, public exposure, and unexpected
+  endpoint changes.
+- Do not commit `.terraform/`, state, plan files, credentials, or populated
+  variable files.
+
+## <a name="related">Related Documentation</a>
+
+- [OCI Database Management overview](https://docs.oracle.com/en-us/iaas/database-management/home.htm)
+- [OCI Operations Insights overview](https://docs.oracle.com/en-us/iaas/operations-insights/home.htm)
+- [Database Management private endpoints](https://docs.oracle.com/en-us/iaas/database-management/doc/database-management-private-endpoints.html)
+- [OCI Terraform provider](https://docs.oracle.com/en-us/iaas/tools/terraform-provider-oci/latest/)
+- [OCI Landing Zone Observability Modules](https://github.com/oci-landing-zones/terraform-oci-modules-observability)
+- [OCI Landing Zone Operating Entities](https://github.com/oci-landing-zones/oci-landing-zone-operating-entities)
+
+## <a name="issues">Known Issues</a>
+
+- Operations Insights data can take time to become visible after enablement.
+- Live provider validation proves the PDB feature state at plan time; the exact
+  reviewed plan and normal change-control window are still required for apply.

--- a/database-observability/SPEC.md
+++ b/database-observability/SPEC.md
@@ -1,0 +1,113 @@
+# OCI Landing Zone Database Observability Module Specification
+
+## Requirements
+
+| Name | Version |
+| --- | --- |
+| Terraform | `>= 1.5.0, < 2.0.0` |
+| OCI provider | `>= 6.0.0, < 9.0.0` |
+
+## Providers
+
+| Name | Source |
+| --- | --- |
+| OCI | `oracle/oci` |
+| Terraform built-in | `terraform.io/builtin/terraform` |
+
+## Managed resources
+
+| Name | Type | Purpose |
+| --- | --- | --- |
+| `oci_database_management_db_management_private_endpoint.these` | resource | Optional DBM private endpoints |
+| `oci_opsi_operations_insights_private_endpoint.these` | resource | Optional OPSI private endpoints |
+| `oci_database_management_database_dbm_features_management.cdb` | resource | CDB Database Management lifecycle |
+| `oci_database_management_pluggabledatabase_pluggable_database_dbm_features_management.pdb` | resource | PDB Database Management lifecycle |
+| `oci_database_management_database_dbm_features_management.non_cdb` | resource | Non-CDB Database Management lifecycle |
+| `oci_opsi_database_insight.these` | resource | Operations Insights enablement |
+| `terraform_data.module_contract` | resource | Fail-closed module invariants |
+| `terraform_data.pdb_disable_observation` | resource | CDB disable guard |
+
+## Data sources
+
+| Name | Purpose |
+| --- | --- |
+| `oci_database_management_managed_database.pdb_disable_observation` | Reads current PDB Database Management feature status during `DISABLE_CDB` planning |
+
+## Inputs
+
+| Name | Type | Default | Required | Description |
+| --- | --- | --- | :---: | --- |
+| `database_observability_configuration` | object | n/a | yes | Module configuration described below |
+| `tenancy_ocid` | string | `null` | no | Required only for `TENANCY-ROOT` |
+| `compartments_dependency` | `map(object({id=string}))` | `{}` | no | Landing Zone compartment outputs |
+| `vcns_dependency` | `map(object({id=string}))` | `{}` | no | Landing Zone VCN outputs |
+| `subnets_dependency` | `map(object({id=string}))` | `{}` | no | Landing Zone subnet outputs |
+| `network_security_groups_dependency` | `map(object({id=string}))` | `{}` | no | Landing Zone NSG outputs |
+| `databases_dependency` | `map(object({id=string}))` | `{}` | no | Cloud database and PDB outputs |
+| `managed_databases_dependency` | `map(object({id=string}))` | `{}` | no | DBM managed-database identities used for disable verification |
+| `vault_secrets_dependency` | `map(object({id=string}))` | `{}` | no | Vault secret outputs |
+| `dbm_private_endpoints_dependency` | `map(object({id=string}))` | `{}` | no | Existing DBM private endpoints |
+| `opsi_private_endpoints_dependency` | `map(object({id=string}))` | `{}` | no | Existing OPSI private endpoints |
+| `enable_output` | bool | `true` | no | Enables module outputs |
+| `module_name` | string | `"database-observability"` | no | Landing Zone module tag |
+
+### `database_observability_configuration`
+
+| Attribute | Type | Default | Required | Description |
+| --- | --- | --- | :---: | --- |
+| `default_compartment_id` | string | n/a | yes | Literal OCID, compartment dependency key, or `TENANCY-ROOT` |
+| `default_defined_tags` | `map(string)` | `{}` | no | Default defined tags |
+| `default_freeform_tags` | `map(string)` | `{}` | no | Default freeform tags |
+| `lifecycle_id` | string | n/a | yes | Stable ownership identifier |
+| `operation_stage` | string | `"ENABLE"` | no | `ENABLE`, `DISABLE_TARGETS`, or `DISABLE_CDB` |
+| `dbm_private_endpoints` | map(object) | `{}` | no | DBM private endpoints managed by this module |
+| `opsi_private_endpoints` | map(object) | `{}` | no | OPSI private endpoints managed by this module |
+| `databases` | map(object) | n/a | yes | Reviewed database targets keyed by stable logical name |
+
+### Database target object
+
+| Attribute | Type | Default | Required | Description |
+| --- | --- | --- | :---: | --- |
+| `compartment_id` | string | default compartment | no | Literal OCID or compartment key |
+| `database_id` | string | n/a | yes | Literal cloud database/PDB OCID or database key |
+| `database_type` | string | n/a | yes | `CDB`, `PDB`, or `NON_CDB` |
+| `parent_database_key` | string | `null` | PDB only | Key of an `ADVANCED` CDB in the same map |
+| `managed_database_id` | string | `null` | disable only | Literal managed-database OCID or dependency key |
+| `dbm_private_endpoint_id` | string | n/a | yes | Created endpoint key, dependency key, or literal OCID |
+| `opsi_private_endpoint_id` | string | `null` | OPSI only | Created endpoint key, dependency key, or literal OCID |
+| `enable_operations_insights` | bool | `false` | no | Creates a Database Insight |
+| `management_type` | string | `"ADVANCED"` | no | `BASIC` or `ADVANCED` |
+| `service_name` | string | n/a | yes | Reviewed listener service name |
+| `password_secret_id` | string | n/a | yes | Vault secret dependency key or literal OCID |
+| `ssl_secret_id` | string | `null` | TCPS only | Vault secret for SSL keystore/truststore details |
+| `monitoring_user` | string | `"DBSNMP"` | no | Database monitoring user |
+| `role` | string | `"NORMAL"` | no | Supported OCI database connection role |
+| `protocol` | string | `"TCP"` | no | `TCP` or `TCPS` |
+| `port` | number | `1521` | no | Listener port from 1 through 65535 |
+| `defined_tags` | `map(string)` | `{}` | no | Per-target defined tags |
+| `freeform_tags` | `map(string)` | `{}` | no | Per-target freeform tags |
+
+The machine-readable equivalent is
+[`schemas/database-observability.schema.json`](./schemas/database-observability.schema.json).
+
+## Outputs
+
+| Name | Description |
+| --- | --- |
+| `dbm_private_endpoints` | Created DBM private endpoint identifiers and placement |
+| `opsi_private_endpoints` | Created OPSI private endpoint identifiers and placement |
+| `database_management` | DBM action-resource IDs by stable target key |
+| `database_insights` | Operations Insights IDs by stable target key |
+| `operation_receipt` | Non-secret stage metadata; never an authorization token |
+
+## Invariants
+
+- A configuration contains at least one reviewed target.
+- A PDB references an `ADVANCED` CDB in the same target map.
+- Plaintext passwords and private keys are not module inputs.
+- PDBs use the provider's PDB-specific DBM resource.
+- CDB disablement cannot occur in the first disable stage.
+- `DISABLE_CDB` requires current provider-backed PDB observations.
+- Reused dependencies are not created or deleted by this module.
+- Every production apply uses the unchanged, reviewed plan produced for the
+  selected execution context.

--- a/database-observability/blueprints/one-oe/README.md
+++ b/database-observability/blueprints/one-oe/README.md
@@ -1,0 +1,20 @@
+# One-OE blueprint fragments
+
+These JSON files are source fragments for the
+`oci-landing-zone-operating-entities` configuration/generation workflow. They
+follow its uppercase stable-key convention and are intended to be merged into
+an observability stack input after the database platform, network, compartment,
+managed-database, and Vault secret outputs are known.
+
+They are not standalone deployments. The owning generator or composition root
+must:
+
+- resolve every dependency key through the matching module output;
+- replace listener-service placeholders from a private reviewed inventory;
+- preserve the CDB/PDB parent relationship;
+- keep Vault secret values outside JSON and Terraform variables; and
+- run a reviewed plan in the selected tenancy and region.
+
+`base-database-service.json` covers a Base Database CDB/PDB pair.
+`exadata-database-service.json` covers the One-OE ExaDB-D shared database
+compartment and network key convention.

--- a/database-observability/blueprints/one-oe/base-database-service.json
+++ b/database-observability/blueprints/one-oe/base-database-service.json
@@ -1,0 +1,58 @@
+{
+  "database_observability_configuration": {
+    "default_compartment_id": "CMP-LZ-APPLICATION-DB-KEY",
+    "default_freeform_tags": {
+      "environment": "production",
+      "owner": "database-platform"
+    },
+    "lifecycle_id": "oneoe-base-db-observability",
+    "operation_stage": "ENABLE",
+    "dbm_private_endpoints": {
+      "DBM-BASE-DB-PE-KEY": {
+        "name": "dbm-base-db-private-endpoint",
+        "description": "Private Database Management access for the One-OE Base Database platform.",
+        "subnet_id": "SUBNET-LZ-APPLICATION-DB-KEY",
+        "nsg_ids": [
+          "NSG-LZ-APPLICATION-DB-OBSERVABILITY-KEY"
+        ],
+        "is_dns_resolution_enabled": true
+      }
+    },
+    "opsi_private_endpoints": {
+      "OPSI-BASE-DB-PE-KEY": {
+        "display_name": "opsi-base-db-private-endpoint",
+        "description": "Private Operations Insights access for the One-OE Base Database platform.",
+        "vcn_id": "VCN-LZ-APPLICATION-DB-KEY",
+        "subnet_id": "SUBNET-LZ-APPLICATION-DB-KEY",
+        "nsg_ids": [
+          "NSG-LZ-APPLICATION-DB-OBSERVABILITY-KEY"
+        ]
+      }
+    },
+    "databases": {
+      "BASE-DB-CDB-KEY": {
+        "database_id": "DATABASE-BASE-DB-CDB-KEY",
+        "database_type": "CDB",
+        "managed_database_id": "MANAGED-DATABASE-BASE-DB-CDB-KEY",
+        "dbm_private_endpoint_id": "DBM-BASE-DB-PE-KEY",
+        "opsi_private_endpoint_id": "OPSI-BASE-DB-PE-KEY",
+        "enable_operations_insights": true,
+        "management_type": "ADVANCED",
+        "service_name": "<CDB_LISTENER_SERVICE>",
+        "password_secret_id": "SECRET-BASE-DB-CDB-DBSNMP-KEY"
+      },
+      "BASE-DB-PDB-KEY": {
+        "database_id": "DATABASE-BASE-DB-PDB-KEY",
+        "database_type": "PDB",
+        "parent_database_key": "BASE-DB-CDB-KEY",
+        "managed_database_id": "MANAGED-DATABASE-BASE-DB-PDB-KEY",
+        "dbm_private_endpoint_id": "DBM-BASE-DB-PE-KEY",
+        "opsi_private_endpoint_id": "OPSI-BASE-DB-PE-KEY",
+        "enable_operations_insights": true,
+        "management_type": "ADVANCED",
+        "service_name": "<PDB_LISTENER_SERVICE>",
+        "password_secret_id": "SECRET-BASE-DB-PDB-DBSNMP-KEY"
+      }
+    }
+  }
+}

--- a/database-observability/blueprints/one-oe/exadata-database-service.json
+++ b/database-observability/blueprints/one-oe/exadata-database-service.json
@@ -1,0 +1,60 @@
+{
+  "database_observability_configuration": {
+    "default_compartment_id": "CMP-LZ-SHARED-EXACS-DB-KEY",
+    "default_freeform_tags": {
+      "environment": "production",
+      "owner": "database-platform"
+    },
+    "lifecycle_id": "oneoe-exadb-observability",
+    "operation_stage": "ENABLE",
+    "dbm_private_endpoints": {
+      "DBM-EXADB-PE-KEY": {
+        "name": "dbm-exadb-private-endpoint",
+        "description": "Private Database Management access for the One-OE ExaDB-D platform.",
+        "subnet_id": "SUBNET-LZ-EXACS-DB-KEY",
+        "nsg_ids": [
+          "NSG-LZ-EXACS-OBSERVABILITY-KEY"
+        ],
+        "is_cluster": true,
+        "is_dns_resolution_enabled": true
+      }
+    },
+    "opsi_private_endpoints": {
+      "OPSI-EXADB-PE-KEY": {
+        "display_name": "opsi-exadb-private-endpoint",
+        "description": "Private Operations Insights access for the One-OE ExaDB-D platform.",
+        "vcn_id": "VCN-LZ-EXACS-KEY",
+        "subnet_id": "SUBNET-LZ-EXACS-DB-KEY",
+        "nsg_ids": [
+          "NSG-LZ-EXACS-OBSERVABILITY-KEY"
+        ],
+        "is_used_for_rac_dbs": true
+      }
+    },
+    "databases": {
+      "EXADB-CDB-KEY": {
+        "database_id": "DATABASE-EXADB-CDB-KEY",
+        "database_type": "CDB",
+        "managed_database_id": "MANAGED-DATABASE-EXADB-CDB-KEY",
+        "dbm_private_endpoint_id": "DBM-EXADB-PE-KEY",
+        "opsi_private_endpoint_id": "OPSI-EXADB-PE-KEY",
+        "enable_operations_insights": true,
+        "management_type": "ADVANCED",
+        "service_name": "<CDB_LISTENER_SERVICE>",
+        "password_secret_id": "SECRET-EXADB-CDB-DBSNMP-KEY"
+      },
+      "EXADB-PDB-KEY": {
+        "database_id": "DATABASE-EXADB-PDB-KEY",
+        "database_type": "PDB",
+        "parent_database_key": "EXADB-CDB-KEY",
+        "managed_database_id": "MANAGED-DATABASE-EXADB-PDB-KEY",
+        "dbm_private_endpoint_id": "DBM-EXADB-PE-KEY",
+        "opsi_private_endpoint_id": "OPSI-EXADB-PE-KEY",
+        "enable_operations_insights": true,
+        "management_type": "ADVANCED",
+        "service_name": "<PDB_LISTENER_SERVICE>",
+        "password_secret_id": "SECRET-EXADB-PDB-DBSNMP-KEY"
+      }
+    }
+  }
+}

--- a/database-observability/examples/base-database/README.md
+++ b/database-observability/examples/base-database/README.md
@@ -1,0 +1,17 @@
+# Base Database example
+
+This example creates Database Management and Operations Insights private
+endpoints and enables a reviewed non-container Base Database target. All OCI
+resource values are supplied as Landing Zone dependency keys; the example
+contains no credentials, private keys, or plaintext database passwords.
+
+1. Copy `input.auto.tfvars.json.template` to an ignored
+   `input.auto.tfvars.json`.
+2. Replace each placeholder with an owner-reviewed value or populate the
+   dependency maps from producing Landing Zone modules.
+3. Authenticate through the execution environment, run `terraform init`, and
+   review a saved plan before apply.
+
+The Vault secret must contain the monitoring-user password. Terraform state
+still contains resource identifiers and secret references, so use an encrypted
+remote backend with restricted access.

--- a/database-observability/examples/base-database/input.auto.tfvars.json.template
+++ b/database-observability/examples/base-database/input.auto.tfvars.json.template
@@ -1,0 +1,76 @@
+{
+  "region": "<OCI_REGION>",
+  "database_observability_configuration": {
+    "default_compartment_id": "CMP-DATABASE-KEY",
+    "default_freeform_tags": {
+      "environment": "production",
+      "owner": "database-platform"
+    },
+    "lifecycle_id": "prod-db-observability",
+    "operation_stage": "ENABLE",
+    "dbm_private_endpoints": {
+      "DBM-PE-KEY": {
+        "name": "dbm-private-endpoint",
+        "description": "Private Database Management access for production databases.",
+        "subnet_id": "SUBNET-DATABASE-PRIVATE-KEY",
+        "nsg_ids": [
+          "NSG-DATABASE-OBSERVABILITY-KEY"
+        ],
+        "is_dns_resolution_enabled": true
+      }
+    },
+    "opsi_private_endpoints": {
+      "OPSI-PE-KEY": {
+        "display_name": "opsi-private-endpoint",
+        "description": "Private Operations Insights access for production databases.",
+        "vcn_id": "VCN-DATABASE-KEY",
+        "subnet_id": "SUBNET-DATABASE-PRIVATE-KEY",
+        "nsg_ids": [
+          "NSG-DATABASE-OBSERVABILITY-KEY"
+        ]
+      }
+    },
+    "databases": {
+      "PROD-NONCDB-KEY": {
+        "database_id": "DATABASE-PROD-NONCDB-KEY",
+        "database_type": "NON_CDB",
+        "dbm_private_endpoint_id": "DBM-PE-KEY",
+        "opsi_private_endpoint_id": "OPSI-PE-KEY",
+        "enable_operations_insights": true,
+        "management_type": "ADVANCED",
+        "service_name": "<DATABASE_LISTENER_SERVICE>",
+        "password_secret_id": "SECRET-DBSNMP-KEY"
+      }
+    }
+  },
+  "compartments_dependency": {
+    "CMP-DATABASE-KEY": {
+      "id": "<DATABASE_COMPARTMENT_OCID>"
+    }
+  },
+  "vcns_dependency": {
+    "VCN-DATABASE-KEY": {
+      "id": "<DATABASE_VCN_OCID>"
+    }
+  },
+  "subnets_dependency": {
+    "SUBNET-DATABASE-PRIVATE-KEY": {
+      "id": "<DATABASE_PRIVATE_SUBNET_OCID>"
+    }
+  },
+  "network_security_groups_dependency": {
+    "NSG-DATABASE-OBSERVABILITY-KEY": {
+      "id": "<DATABASE_OBSERVABILITY_NSG_OCID>"
+    }
+  },
+  "databases_dependency": {
+    "DATABASE-PROD-NONCDB-KEY": {
+      "id": "<DATABASE_OCID>"
+    }
+  },
+  "vault_secrets_dependency": {
+    "SECRET-DBSNMP-KEY": {
+      "id": "<DBSNMP_PASSWORD_SECRET_OCID>"
+    }
+  }
+}

--- a/database-observability/examples/base-database/main.tf
+++ b/database-observability/examples/base-database/main.tf
@@ -1,0 +1,30 @@
+# Copyright (c) 2026 Contributors to oci-dbman-opsi.
+# Licensed under the Universal Permissive License v 1.0.
+
+module "database_observability" {
+  source = "../.."
+
+  tenancy_ocid                         = var.tenancy_ocid
+  database_observability_configuration = var.database_observability_configuration
+  compartments_dependency              = var.compartments_dependency
+  vcns_dependency                      = var.vcns_dependency
+  subnets_dependency                   = var.subnets_dependency
+  network_security_groups_dependency   = var.network_security_groups_dependency
+  databases_dependency                 = var.databases_dependency
+  managed_databases_dependency         = var.managed_databases_dependency
+  vault_secrets_dependency             = var.vault_secrets_dependency
+  dbm_private_endpoints_dependency     = var.dbm_private_endpoints_dependency
+  opsi_private_endpoints_dependency    = var.opsi_private_endpoints_dependency
+}
+
+output "database_management" {
+  value = module.database_observability.database_management
+}
+
+output "database_insights" {
+  value = module.database_observability.database_insights
+}
+
+output "operation_receipt" {
+  value = module.database_observability.operation_receipt
+}

--- a/database-observability/examples/base-database/providers.tf
+++ b/database-observability/examples/base-database/providers.tf
@@ -1,0 +1,17 @@
+# Copyright (c) 2026 Contributors to oci-dbman-opsi.
+# Licensed under the Universal Permissive License v 1.0.
+
+terraform {
+  required_version = ">= 1.5.0, < 2.0.0"
+
+  required_providers {
+    oci = {
+      source  = "oracle/oci"
+      version = ">= 6.0.0, < 9.0.0"
+    }
+  }
+}
+
+provider "oci" {
+  region = var.region
+}

--- a/database-observability/examples/base-database/variables.tf
+++ b/database-observability/examples/base-database/variables.tf
@@ -1,0 +1,64 @@
+# Copyright (c) 2026 Contributors to oci-dbman-opsi.
+# Licensed under the Universal Permissive License v 1.0.
+
+variable "region" {
+  description = "OCI region. Authentication is inherited from the execution environment."
+  type        = string
+}
+
+variable "tenancy_ocid" {
+  description = "Required only when TENANCY-ROOT is used as a compartment reference."
+  type        = string
+  default     = null
+  nullable    = true
+}
+
+variable "database_observability_configuration" {
+  description = "Configuration passed unchanged to the database-observability module."
+  type        = any
+}
+
+variable "compartments_dependency" {
+  type    = map(object({ id = string }))
+  default = {}
+}
+
+variable "vcns_dependency" {
+  type    = map(object({ id = string }))
+  default = {}
+}
+
+variable "subnets_dependency" {
+  type    = map(object({ id = string }))
+  default = {}
+}
+
+variable "network_security_groups_dependency" {
+  type    = map(object({ id = string }))
+  default = {}
+}
+
+variable "databases_dependency" {
+  type    = map(object({ id = string }))
+  default = {}
+}
+
+variable "managed_databases_dependency" {
+  type    = map(object({ id = string }))
+  default = {}
+}
+
+variable "vault_secrets_dependency" {
+  type    = map(object({ id = string }))
+  default = {}
+}
+
+variable "dbm_private_endpoints_dependency" {
+  type    = map(object({ id = string }))
+  default = {}
+}
+
+variable "opsi_private_endpoints_dependency" {
+  type    = map(object({ id = string }))
+  default = {}
+}

--- a/database-observability/examples/exadata-database-service/README.md
+++ b/database-observability/examples/exadata-database-service/README.md
@@ -1,0 +1,19 @@
+# Exadata Database Service example
+
+This example enables Database Management and Operations Insights for an Exadata
+Database Service CDB/PDB pair. It follows the One-OE Landing Zone reference-key
+style used by the ExaDB-D workload extension.
+
+The CDB is always enabled before the PDB. Disabling is intentionally staged:
+
+1. Change `operation_stage` to `DISABLE_TARGETS`, review and apply the plan.
+   Operations Insights is removed before DBM target disablement.
+2. Confirm collection has stopped and create a new plan with
+   `operation_stage` set to `DISABLE_CDB`.
+3. The second plan reads each PDB through its `managed_database_id` and fails
+   unless its Database Management feature is already disabled.
+
+Copy `input.auto.tfvars.json.template` to an ignored
+`input.auto.tfvars.json`, populate its dependency maps from the Landing Zone
+outputs, authenticate through the execution environment, and review a saved
+plan before apply.

--- a/database-observability/examples/exadata-database-service/input.auto.tfvars.json.template
+++ b/database-observability/examples/exadata-database-service/input.auto.tfvars.json.template
@@ -1,0 +1,105 @@
+{
+  "region": "<OCI_REGION>",
+  "database_observability_configuration": {
+    "default_compartment_id": "CMP-LZ-SHARED-EXACS-DB-KEY",
+    "default_freeform_tags": {
+      "environment": "production",
+      "owner": "database-platform"
+    },
+    "lifecycle_id": "prod-exadb-observability",
+    "operation_stage": "ENABLE",
+    "dbm_private_endpoints": {
+      "DBM-EXADB-PE-KEY": {
+        "name": "dbm-exadb-private-endpoint",
+        "description": "Private Database Management access for Exadata Database Service.",
+        "subnet_id": "SUBNET-LZ-EXACS-DB-KEY",
+        "nsg_ids": [
+          "NSG-LZ-EXACS-OBSERVABILITY-KEY"
+        ],
+        "is_cluster": true,
+        "is_dns_resolution_enabled": true
+      }
+    },
+    "opsi_private_endpoints": {
+      "OPSI-EXADB-PE-KEY": {
+        "display_name": "opsi-exadb-private-endpoint",
+        "description": "Private Operations Insights access for Exadata Database Service.",
+        "vcn_id": "VCN-LZ-EXACS-KEY",
+        "subnet_id": "SUBNET-LZ-EXACS-DB-KEY",
+        "nsg_ids": [
+          "NSG-LZ-EXACS-OBSERVABILITY-KEY"
+        ],
+        "is_used_for_rac_dbs": true
+      }
+    },
+    "databases": {
+      "EXADB-CDB-KEY": {
+        "database_id": "DATABASE-EXADB-CDB-KEY",
+        "database_type": "CDB",
+        "managed_database_id": "MANAGED-DATABASE-EXADB-CDB-KEY",
+        "dbm_private_endpoint_id": "DBM-EXADB-PE-KEY",
+        "opsi_private_endpoint_id": "OPSI-EXADB-PE-KEY",
+        "enable_operations_insights": true,
+        "management_type": "ADVANCED",
+        "service_name": "<CDB_LISTENER_SERVICE>",
+        "password_secret_id": "SECRET-EXADB-CDB-DBSNMP-KEY"
+      },
+      "EXADB-PDB-KEY": {
+        "database_id": "DATABASE-EXADB-PDB-KEY",
+        "database_type": "PDB",
+        "parent_database_key": "EXADB-CDB-KEY",
+        "managed_database_id": "MANAGED-DATABASE-EXADB-PDB-KEY",
+        "dbm_private_endpoint_id": "DBM-EXADB-PE-KEY",
+        "opsi_private_endpoint_id": "OPSI-EXADB-PE-KEY",
+        "enable_operations_insights": true,
+        "management_type": "ADVANCED",
+        "service_name": "<PDB_LISTENER_SERVICE>",
+        "password_secret_id": "SECRET-EXADB-PDB-DBSNMP-KEY"
+      }
+    }
+  },
+  "compartments_dependency": {
+    "CMP-LZ-SHARED-EXACS-DB-KEY": {
+      "id": "<EXADB_DATABASE_COMPARTMENT_OCID>"
+    }
+  },
+  "vcns_dependency": {
+    "VCN-LZ-EXACS-KEY": {
+      "id": "<EXADB_VCN_OCID>"
+    }
+  },
+  "subnets_dependency": {
+    "SUBNET-LZ-EXACS-DB-KEY": {
+      "id": "<EXADB_DATABASE_SUBNET_OCID>"
+    }
+  },
+  "network_security_groups_dependency": {
+    "NSG-LZ-EXACS-OBSERVABILITY-KEY": {
+      "id": "<EXADB_OBSERVABILITY_NSG_OCID>"
+    }
+  },
+  "databases_dependency": {
+    "DATABASE-EXADB-CDB-KEY": {
+      "id": "<EXADB_CDB_OCID>"
+    },
+    "DATABASE-EXADB-PDB-KEY": {
+      "id": "<EXADB_PDB_OCID>"
+    }
+  },
+  "managed_databases_dependency": {
+    "MANAGED-DATABASE-EXADB-CDB-KEY": {
+      "id": "<EXADB_CDB_MANAGED_DATABASE_OCID>"
+    },
+    "MANAGED-DATABASE-EXADB-PDB-KEY": {
+      "id": "<EXADB_PDB_MANAGED_DATABASE_OCID>"
+    }
+  },
+  "vault_secrets_dependency": {
+    "SECRET-EXADB-CDB-DBSNMP-KEY": {
+      "id": "<EXADB_CDB_DBSNMP_PASSWORD_SECRET_OCID>"
+    },
+    "SECRET-EXADB-PDB-DBSNMP-KEY": {
+      "id": "<EXADB_PDB_DBSNMP_PASSWORD_SECRET_OCID>"
+    }
+  }
+}

--- a/database-observability/examples/exadata-database-service/main.tf
+++ b/database-observability/examples/exadata-database-service/main.tf
@@ -1,0 +1,30 @@
+# Copyright (c) 2026 Contributors to oci-dbman-opsi.
+# Licensed under the Universal Permissive License v 1.0.
+
+module "database_observability" {
+  source = "../.."
+
+  tenancy_ocid                         = var.tenancy_ocid
+  database_observability_configuration = var.database_observability_configuration
+  compartments_dependency              = var.compartments_dependency
+  vcns_dependency                      = var.vcns_dependency
+  subnets_dependency                   = var.subnets_dependency
+  network_security_groups_dependency   = var.network_security_groups_dependency
+  databases_dependency                 = var.databases_dependency
+  managed_databases_dependency         = var.managed_databases_dependency
+  vault_secrets_dependency             = var.vault_secrets_dependency
+  dbm_private_endpoints_dependency     = var.dbm_private_endpoints_dependency
+  opsi_private_endpoints_dependency    = var.opsi_private_endpoints_dependency
+}
+
+output "database_management" {
+  value = module.database_observability.database_management
+}
+
+output "database_insights" {
+  value = module.database_observability.database_insights
+}
+
+output "operation_receipt" {
+  value = module.database_observability.operation_receipt
+}

--- a/database-observability/examples/exadata-database-service/providers.tf
+++ b/database-observability/examples/exadata-database-service/providers.tf
@@ -1,0 +1,17 @@
+# Copyright (c) 2026 Contributors to oci-dbman-opsi.
+# Licensed under the Universal Permissive License v 1.0.
+
+terraform {
+  required_version = ">= 1.5.0, < 2.0.0"
+
+  required_providers {
+    oci = {
+      source  = "oracle/oci"
+      version = ">= 6.0.0, < 9.0.0"
+    }
+  }
+}
+
+provider "oci" {
+  region = var.region
+}

--- a/database-observability/examples/exadata-database-service/variables.tf
+++ b/database-observability/examples/exadata-database-service/variables.tf
@@ -1,0 +1,64 @@
+# Copyright (c) 2026 Contributors to oci-dbman-opsi.
+# Licensed under the Universal Permissive License v 1.0.
+
+variable "region" {
+  description = "OCI region. Authentication is inherited from the execution environment."
+  type        = string
+}
+
+variable "tenancy_ocid" {
+  description = "Required only when TENANCY-ROOT is used as a compartment reference."
+  type        = string
+  default     = null
+  nullable    = true
+}
+
+variable "database_observability_configuration" {
+  description = "Configuration passed unchanged to the database-observability module."
+  type        = any
+}
+
+variable "compartments_dependency" {
+  type    = map(object({ id = string }))
+  default = {}
+}
+
+variable "vcns_dependency" {
+  type    = map(object({ id = string }))
+  default = {}
+}
+
+variable "subnets_dependency" {
+  type    = map(object({ id = string }))
+  default = {}
+}
+
+variable "network_security_groups_dependency" {
+  type    = map(object({ id = string }))
+  default = {}
+}
+
+variable "databases_dependency" {
+  type    = map(object({ id = string }))
+  default = {}
+}
+
+variable "managed_databases_dependency" {
+  type    = map(object({ id = string }))
+  default = {}
+}
+
+variable "vault_secrets_dependency" {
+  type    = map(object({ id = string }))
+  default = {}
+}
+
+variable "dbm_private_endpoints_dependency" {
+  type    = map(object({ id = string }))
+  default = {}
+}
+
+variable "opsi_private_endpoints_dependency" {
+  type    = map(object({ id = string }))
+  default = {}
+}

--- a/database-observability/locals.tf
+++ b/database-observability/locals.tf
@@ -1,0 +1,123 @@
+# Copyright (c) 2026 Contributors to oci-dbman-opsi.
+# Licensed under the Universal Permissive License v 1.0.
+
+locals {
+  configuration   = var.database_observability_configuration
+  operation_stage = upper(local.configuration.operation_stage)
+
+  default_compartment_id = (
+    local.configuration.default_compartment_id == "TENANCY-ROOT"
+    ? var.tenancy_ocid
+    : try(
+      var.compartments_dependency[local.configuration.default_compartment_id].id,
+      local.configuration.default_compartment_id,
+    )
+  )
+
+  default_defined_tags  = local.configuration.default_defined_tags
+  default_freeform_tags = local.configuration.default_freeform_tags
+  ownership_tags = merge(
+    local.default_freeform_tags,
+    local.module_tags,
+    {
+      "db-observability-lifecycle-id" = local.configuration.lifecycle_id
+      "db-observability-managed-by"   = "terraform"
+    },
+  )
+
+  dbm_private_endpoint_settings = {
+    for key, endpoint in local.configuration.dbm_private_endpoints : key => merge(endpoint, {
+      compartment_id = try(
+        var.compartments_dependency[endpoint.compartment_id].id,
+        endpoint.compartment_id != null ? endpoint.compartment_id : local.default_compartment_id,
+      )
+      subnet_id = try(var.subnets_dependency[endpoint.subnet_id].id, endpoint.subnet_id)
+      nsg_ids = [
+        for nsg_id in endpoint.nsg_ids :
+        try(var.network_security_groups_dependency[nsg_id].id, nsg_id)
+      ]
+      defined_tags  = merge(local.default_defined_tags, endpoint.defined_tags)
+      freeform_tags = merge(local.ownership_tags, endpoint.freeform_tags)
+    })
+  }
+
+  opsi_private_endpoint_settings = {
+    for key, endpoint in local.configuration.opsi_private_endpoints : key => merge(endpoint, {
+      compartment_id = try(
+        var.compartments_dependency[endpoint.compartment_id].id,
+        endpoint.compartment_id != null ? endpoint.compartment_id : local.default_compartment_id,
+      )
+      vcn_id    = try(var.vcns_dependency[endpoint.vcn_id].id, endpoint.vcn_id)
+      subnet_id = try(var.subnets_dependency[endpoint.subnet_id].id, endpoint.subnet_id)
+      nsg_ids = [
+        for nsg_id in endpoint.nsg_ids :
+        try(var.network_security_groups_dependency[nsg_id].id, nsg_id)
+      ]
+      defined_tags  = merge(local.default_defined_tags, endpoint.defined_tags)
+      freeform_tags = merge(local.ownership_tags, endpoint.freeform_tags)
+    })
+  }
+}
+
+locals {
+  database_targets = {
+    for key, target in local.configuration.databases : key => merge(target, {
+      database_type = upper(target.database_type)
+      compartment_id = try(
+        var.compartments_dependency[target.compartment_id].id,
+        target.compartment_id != null ? target.compartment_id : local.default_compartment_id,
+      )
+      database_id = try(var.databases_dependency[target.database_id].id, target.database_id)
+      managed_database_id = (
+        target.managed_database_id != null
+        ? try(var.managed_databases_dependency[target.managed_database_id].id, target.managed_database_id)
+        : null
+      )
+      dbm_private_endpoint_id = try(
+        oci_database_management_db_management_private_endpoint.these[target.dbm_private_endpoint_id].id,
+        var.dbm_private_endpoints_dependency[target.dbm_private_endpoint_id].id,
+        target.dbm_private_endpoint_id,
+      )
+      opsi_private_endpoint_id = (
+        target.opsi_private_endpoint_id != null
+        ? try(
+          oci_opsi_operations_insights_private_endpoint.these[target.opsi_private_endpoint_id].id,
+          var.opsi_private_endpoints_dependency[target.opsi_private_endpoint_id].id,
+          target.opsi_private_endpoint_id,
+        )
+        : null
+      )
+      password_secret_id = try(
+        var.vault_secrets_dependency[target.password_secret_id].id,
+        target.password_secret_id,
+      )
+      ssl_secret_id = (
+        target.ssl_secret_id != null
+        ? try(var.vault_secrets_dependency[target.ssl_secret_id].id, target.ssl_secret_id)
+        : null
+      )
+      defined_tags  = merge(local.default_defined_tags, target.defined_tags)
+      freeform_tags = merge(local.ownership_tags, target.freeform_tags)
+    })
+  }
+
+  cdb_targets = {
+    for key, target in local.database_targets : key => target
+    if target.database_type == "CDB"
+  }
+
+  pdb_targets = {
+    for key, target in local.database_targets : key => target
+    if target.database_type == "PDB"
+  }
+
+  non_cdb_targets = {
+    for key, target in local.database_targets : key => target
+    if target.database_type == "NON_CDB"
+  }
+
+  opsi_targets = {
+    for key, target in local.database_targets : key => target
+    if local.operation_stage == "ENABLE" && target.enable_operations_insights
+  }
+}

--- a/database-observability/main.tf
+++ b/database-observability/main.tf
@@ -1,0 +1,200 @@
+# Copyright (c) 2026 Contributors to oci-dbman-opsi.
+# Licensed under the Universal Permissive License v 1.0.
+
+resource "terraform_data" "module_contract" {
+  input = {
+    database_keys   = sort(keys(local.configuration.databases))
+    lifecycle_id    = local.configuration.lifecycle_id
+    operation_stage = local.operation_stage
+  }
+
+  lifecycle {
+    precondition {
+      condition     = local.configuration.default_compartment_id != "TENANCY-ROOT" || var.tenancy_ocid != null
+      error_message = "tenancy_ocid is required when default_compartment_id is TENANCY-ROOT."
+    }
+
+    precondition {
+      condition     = length(local.configuration.databases) > 0
+      error_message = "database_observability_configuration.databases must contain at least one reviewed target."
+    }
+
+  }
+}
+
+# The second CDB-disable apply reads current provider-backed state for every PDB.
+# A copied local receipt is neither accepted nor needed.
+data "oci_database_management_managed_database" "pdb_disable_observation" {
+  for_each = local.operation_stage == "DISABLE_CDB" ? local.pdb_targets : {}
+
+  managed_database_id = each.value.managed_database_id
+}
+
+resource "terraform_data" "pdb_disable_observation" {
+  count = local.operation_stage == "DISABLE_CDB" ? 1 : 0
+
+  input = {
+    observer        = "oracle/oci managed_database data source"
+    pdb_target_keys = sort(keys(local.pdb_targets))
+  }
+
+  lifecycle {
+    precondition {
+      condition = alltrue([
+        for observed in values(data.oci_database_management_managed_database.pdb_disable_observation) :
+        alltrue([
+          for feature in observed.dbmgmt_feature_configs :
+          upper(feature.feature) != "DIAGNOSTICS_AND_MANAGEMENT" ||
+          contains(["DISABLED", "NOT_ENABLED"], upper(feature.feature_status))
+        ])
+      ])
+      error_message = "DISABLE_CDB requires every observed PDB DIAGNOSTICS_AND_MANAGEMENT feature to be absent, DISABLED, or NOT_ENABLED."
+    }
+  }
+}
+
+resource "oci_database_management_database_dbm_features_management" "cdb" {
+  for_each = local.cdb_targets
+
+  database_id                 = each.value.database_id
+  enable_database_dbm_feature = local.operation_stage != "DISABLE_CDB"
+  can_disable_all_pdbs        = false
+
+  feature_details {
+    feature                           = "DIAGNOSTICS_AND_MANAGEMENT"
+    management_type                   = each.value.management_type
+    can_enable_all_current_pdbs       = false
+    is_auto_enable_pluggable_database = false
+
+    connector_details {
+      connector_type       = "PE"
+      private_end_point_id = each.value.dbm_private_endpoint_id
+    }
+
+    database_connection_details {
+      connection_credentials {
+        credential_type    = each.value.ssl_secret_id != null ? "SSL_DETAILS" : "DETAILS"
+        user_name          = each.value.monitoring_user
+        password_secret_id = each.value.password_secret_id
+        ssl_secret_id      = each.value.ssl_secret_id
+        role               = each.value.role
+      }
+
+      connection_string {
+        connection_type = "BASIC"
+        port            = each.value.port
+        protocol        = each.value.protocol
+        service         = each.value.service_name
+      }
+    }
+  }
+
+  depends_on = [
+    terraform_data.module_contract,
+    terraform_data.pdb_disable_observation,
+  ]
+}
+
+resource "oci_database_management_pluggabledatabase_pluggable_database_dbm_features_management" "pdb" {
+  for_each = local.pdb_targets
+
+  pluggable_database_id                 = each.value.database_id
+  enable_pluggable_database_dbm_feature = local.operation_stage == "ENABLE"
+
+  feature_details {
+    feature                           = "DIAGNOSTICS_AND_MANAGEMENT"
+    management_type                   = each.value.management_type
+    can_enable_all_current_pdbs       = false
+    is_auto_enable_pluggable_database = false
+
+    connector_details {
+      connector_type       = "PE"
+      private_end_point_id = each.value.dbm_private_endpoint_id
+    }
+
+    database_connection_details {
+      connection_credentials {
+        credential_type    = each.value.ssl_secret_id != null ? "SSL_DETAILS" : "DETAILS"
+        user_name          = each.value.monitoring_user
+        password_secret_id = each.value.password_secret_id
+        ssl_secret_id      = each.value.ssl_secret_id
+        role               = each.value.role
+      }
+
+      connection_string {
+        connection_type = "BASIC"
+        port            = each.value.port
+        protocol        = each.value.protocol
+        service         = each.value.service_name
+      }
+    }
+  }
+
+  depends_on = [oci_database_management_database_dbm_features_management.cdb]
+}
+
+resource "oci_database_management_database_dbm_features_management" "non_cdb" {
+  for_each = local.non_cdb_targets
+
+  database_id                 = each.value.database_id
+  enable_database_dbm_feature = local.operation_stage == "ENABLE"
+  can_disable_all_pdbs        = false
+
+  feature_details {
+    feature                           = "DIAGNOSTICS_AND_MANAGEMENT"
+    management_type                   = each.value.management_type
+    can_enable_all_current_pdbs       = false
+    is_auto_enable_pluggable_database = false
+
+    connector_details {
+      connector_type       = "PE"
+      private_end_point_id = each.value.dbm_private_endpoint_id
+    }
+
+    database_connection_details {
+      connection_credentials {
+        credential_type    = each.value.ssl_secret_id != null ? "SSL_DETAILS" : "DETAILS"
+        user_name          = each.value.monitoring_user
+        password_secret_id = each.value.password_secret_id
+        ssl_secret_id      = each.value.ssl_secret_id
+        role               = each.value.role
+      }
+
+      connection_string {
+        connection_type = "BASIC"
+        port            = each.value.port
+        protocol        = each.value.protocol
+        service         = each.value.service_name
+      }
+    }
+  }
+
+  depends_on = [terraform_data.module_contract]
+}
+
+resource "oci_opsi_database_insight" "these" {
+  for_each = local.opsi_targets
+
+  compartment_id           = each.value.compartment_id
+  entity_source            = "PE_COMANAGED_DATABASE"
+  database_id              = each.value.database_id
+  database_resource_type   = each.value.database_type == "PDB" ? "pluggabledatabase" : "database"
+  dbm_private_endpoint_id  = each.value.dbm_private_endpoint_id
+  opsi_private_endpoint_id = each.value.opsi_private_endpoint_id
+  defined_tags             = each.value.defined_tags
+  freeform_tags            = each.value.freeform_tags
+
+  credential_details {
+    credential_type    = "CREDENTIALS_BY_VAULT"
+    user_name          = each.value.monitoring_user
+    role               = each.value.role
+    password_secret_id = each.value.password_secret_id
+    wallet_secret_id   = each.value.ssl_secret_id
+  }
+
+  depends_on = [
+    oci_database_management_database_dbm_features_management.cdb,
+    oci_database_management_pluggabledatabase_pluggable_database_dbm_features_management.pdb,
+    oci_database_management_database_dbm_features_management.non_cdb,
+  ]
+}

--- a/database-observability/metadata.tf
+++ b/database-observability/metadata.tf
@@ -1,0 +1,9 @@
+# Copyright (c) 2026 Contributors to oci-dbman-opsi.
+# Licensed under the Universal Permissive License v 1.0.
+
+locals {
+  module_release = fileexists("${path.module}/../release.txt") ? trimspace(file("${path.module}/../release.txt")) : null
+  module_tags = {
+    "ocilz-terraform-module" = local.module_release != null ? "${var.module_name}/${local.module_release}" : var.module_name
+  }
+}

--- a/database-observability/outputs.tf
+++ b/database-observability/outputs.tf
@@ -1,0 +1,72 @@
+# Copyright (c) 2026 Contributors to oci-dbman-opsi.
+# Licensed under the Universal Permissive License v 1.0.
+
+output "dbm_private_endpoints" {
+  description = "Database Management private endpoints created by this module."
+  value = var.enable_output ? {
+    for key, endpoint in oci_database_management_db_management_private_endpoint.these : key => {
+      id             = endpoint.id
+      compartment_id = endpoint.compartment_id
+      name           = endpoint.name
+      subnet_id      = endpoint.subnet_id
+    }
+  } : null
+}
+
+output "opsi_private_endpoints" {
+  description = "Operations Insights private endpoints created by this module."
+  value = var.enable_output ? {
+    for key, endpoint in oci_opsi_operations_insights_private_endpoint.these : key => {
+      id             = endpoint.id
+      compartment_id = endpoint.compartment_id
+      display_name   = endpoint.display_name
+      subnet_id      = endpoint.subnet_id
+      vcn_id         = endpoint.vcn_id
+    }
+  } : null
+}
+
+output "database_management" {
+  description = "Database Management action-resource identifiers by stable target key."
+  value = var.enable_output ? merge(
+    {
+      for key, resource in oci_database_management_database_dbm_features_management.cdb : key => {
+        id            = resource.id
+        database_type = "CDB"
+      }
+    },
+    {
+      for key, resource in oci_database_management_pluggabledatabase_pluggable_database_dbm_features_management.pdb : key => {
+        id            = resource.id
+        database_type = "PDB"
+      }
+    },
+    {
+      for key, resource in oci_database_management_database_dbm_features_management.non_cdb : key => {
+        id            = resource.id
+        database_type = "NON_CDB"
+      }
+    },
+  ) : null
+}
+
+output "database_insights" {
+  description = "Operations Insights identifiers by stable target key."
+  value = var.enable_output ? {
+    for key, insight in oci_opsi_database_insight.these : key => {
+      id             = insight.id
+      compartment_id = insight.compartment_id
+    }
+  } : null
+}
+
+output "operation_receipt" {
+  description = "Non-secret operation metadata. It is an audit aid, never authorization for the next stage."
+  value = var.enable_output ? {
+    lifecycle_id                     = local.configuration.lifecycle_id
+    operation_stage                  = local.operation_stage
+    database_keys                    = sort(keys(local.database_targets))
+    authoritative_observation_source = local.operation_stage == "DISABLE_CDB" ? "oracle/oci managed_database data source" : null
+    next_required_stage              = local.operation_stage == "DISABLE_TARGETS" && length(local.pdb_targets) > 0 ? "DISABLE_CDB after a new reviewed plan verifies every PDB is disabled" : null
+  } : null
+}

--- a/database-observability/private-endpoints.tf
+++ b/database-observability/private-endpoints.tf
@@ -1,0 +1,34 @@
+# Copyright (c) 2026 Contributors to oci-dbman-opsi.
+# Licensed under the Universal Permissive License v 1.0.
+
+resource "oci_database_management_db_management_private_endpoint" "these" {
+  for_each = local.dbm_private_endpoint_settings
+
+  compartment_id            = each.value.compartment_id
+  name                      = each.value.name
+  description               = each.value.description
+  subnet_id                 = each.value.subnet_id
+  nsg_ids                   = each.value.nsg_ids
+  is_cluster                = each.value.is_cluster
+  is_dns_resolution_enabled = each.value.is_dns_resolution_enabled
+  defined_tags              = each.value.defined_tags
+  freeform_tags             = each.value.freeform_tags
+
+  depends_on = [terraform_data.module_contract]
+}
+
+resource "oci_opsi_operations_insights_private_endpoint" "these" {
+  for_each = local.opsi_private_endpoint_settings
+
+  compartment_id      = each.value.compartment_id
+  display_name        = each.value.display_name
+  description         = each.value.description
+  vcn_id              = each.value.vcn_id
+  subnet_id           = each.value.subnet_id
+  nsg_ids             = each.value.nsg_ids
+  is_used_for_rac_dbs = each.value.is_used_for_rac_dbs
+  defined_tags        = each.value.defined_tags
+  freeform_tags       = each.value.freeform_tags
+
+  depends_on = [terraform_data.module_contract]
+}

--- a/database-observability/providers.tf
+++ b/database-observability/providers.tf
@@ -1,0 +1,13 @@
+# Copyright (c) 2026 Contributors to oci-dbman-opsi.
+# Licensed under the Universal Permissive License v 1.0.
+
+terraform {
+  required_version = ">= 1.5.0, < 2.0.0"
+
+  required_providers {
+    oci = {
+      source  = "oracle/oci"
+      version = ">= 6.0.0, < 9.0.0"
+    }
+  }
+}

--- a/database-observability/schemas/database-observability.schema.json
+++ b/database-observability/schemas/database-observability.schema.json
@@ -1,0 +1,307 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/adibirzu/oci-dbman-opsi/database-observability/schemas/database-observability.schema.json",
+  "title": "OCI Landing Zone Database Observability Terraform Variables",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "region",
+    "database_observability_configuration"
+  ],
+  "properties": {
+    "region": {
+      "type": "string",
+      "minLength": 1
+    },
+    "tenancy_ocid": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "database_observability_configuration": {
+      "$ref": "#/$defs/configuration"
+    },
+    "compartments_dependency": {
+      "$ref": "#/$defs/dependencyMap"
+    },
+    "vcns_dependency": {
+      "$ref": "#/$defs/dependencyMap"
+    },
+    "subnets_dependency": {
+      "$ref": "#/$defs/dependencyMap"
+    },
+    "network_security_groups_dependency": {
+      "$ref": "#/$defs/dependencyMap"
+    },
+    "databases_dependency": {
+      "$ref": "#/$defs/dependencyMap"
+    },
+    "managed_databases_dependency": {
+      "$ref": "#/$defs/dependencyMap"
+    },
+    "vault_secrets_dependency": {
+      "$ref": "#/$defs/dependencyMap"
+    },
+    "dbm_private_endpoints_dependency": {
+      "$ref": "#/$defs/dependencyMap"
+    },
+    "opsi_private_endpoints_dependency": {
+      "$ref": "#/$defs/dependencyMap"
+    }
+  },
+  "$defs": {
+    "dependencyMap": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "id"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "tagMap": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "dbmPrivateEndpoint": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "subnet_id"
+      ],
+      "properties": {
+        "compartment_id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "description": {
+          "type": "string"
+        },
+        "subnet_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "nsg_ids": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "is_cluster": {
+          "type": "boolean"
+        },
+        "is_dns_resolution_enabled": {
+          "type": "boolean"
+        },
+        "defined_tags": {
+          "$ref": "#/$defs/tagMap"
+        },
+        "freeform_tags": {
+          "$ref": "#/$defs/tagMap"
+        }
+      }
+    },
+    "opsiPrivateEndpoint": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "display_name",
+        "vcn_id",
+        "subnet_id"
+      ],
+      "properties": {
+        "compartment_id": {
+          "type": "string"
+        },
+        "display_name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "description": {
+          "type": "string"
+        },
+        "vcn_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "subnet_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "nsg_ids": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "is_used_for_rac_dbs": {
+          "type": "boolean"
+        },
+        "defined_tags": {
+          "$ref": "#/$defs/tagMap"
+        },
+        "freeform_tags": {
+          "$ref": "#/$defs/tagMap"
+        }
+      }
+    },
+    "database": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "database_id",
+        "database_type",
+        "dbm_private_endpoint_id",
+        "service_name",
+        "password_secret_id"
+      ],
+      "properties": {
+        "compartment_id": {
+          "type": "string"
+        },
+        "database_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "database_type": {
+          "enum": [
+            "CDB",
+            "PDB",
+            "NON_CDB"
+          ]
+        },
+        "parent_database_key": {
+          "type": "string"
+        },
+        "managed_database_id": {
+          "type": "string"
+        },
+        "dbm_private_endpoint_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "opsi_private_endpoint_id": {
+          "type": "string"
+        },
+        "enable_operations_insights": {
+          "type": "boolean"
+        },
+        "management_type": {
+          "enum": [
+            "BASIC",
+            "ADVANCED"
+          ]
+        },
+        "service_name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "password_secret_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "ssl_secret_id": {
+          "type": "string"
+        },
+        "monitoring_user": {
+          "type": "string",
+          "minLength": 1
+        },
+        "role": {
+          "enum": [
+            "NORMAL",
+            "SYSDBA",
+            "SYSOPER",
+            "SYSASM"
+          ]
+        },
+        "protocol": {
+          "enum": [
+            "TCP",
+            "TCPS"
+          ]
+        },
+        "port": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535
+        },
+        "defined_tags": {
+          "$ref": "#/$defs/tagMap"
+        },
+        "freeform_tags": {
+          "$ref": "#/$defs/tagMap"
+        }
+      }
+    },
+    "configuration": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "default_compartment_id",
+        "lifecycle_id",
+        "databases"
+      ],
+      "properties": {
+        "default_compartment_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "default_defined_tags": {
+          "$ref": "#/$defs/tagMap"
+        },
+        "default_freeform_tags": {
+          "$ref": "#/$defs/tagMap"
+        },
+        "lifecycle_id": {
+          "type": "string",
+          "minLength": 8,
+          "maxLength": 64,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.-]+$"
+        },
+        "operation_stage": {
+          "enum": [
+            "ENABLE",
+            "DISABLE_TARGETS",
+            "DISABLE_CDB"
+          ]
+        },
+        "dbm_private_endpoints": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/dbmPrivateEndpoint"
+          }
+        },
+        "opsi_private_endpoints": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/opsiPrivateEndpoint"
+          }
+        },
+        "databases": {
+          "type": "object",
+          "minProperties": 1,
+          "additionalProperties": {
+            "$ref": "#/$defs/database"
+          }
+        }
+      }
+    }
+  }
+}

--- a/database-observability/variables.tf
+++ b/database-observability/variables.tf
@@ -1,0 +1,229 @@
+# Copyright (c) 2026 Contributors to oci-dbman-opsi.
+# Licensed under the Universal Permissive License v 1.0.
+
+variable "tenancy_ocid" {
+  description = "Tenancy OCID. Required only when TENANCY-ROOT is used as a compartment reference."
+  type        = string
+  default     = null
+  nullable    = true
+}
+
+variable "database_observability_configuration" {
+  description = "Database Management and Operations Insights configuration. Every value ending in _id can be a literal OCID or a key in the matching dependency map."
+  type = object({
+    default_compartment_id = string
+    default_defined_tags   = optional(map(string), {})
+    default_freeform_tags  = optional(map(string), {})
+    lifecycle_id           = string
+    operation_stage        = optional(string, "ENABLE")
+    dbm_private_endpoints = optional(map(object({
+      compartment_id            = optional(string)
+      name                      = string
+      description               = optional(string)
+      subnet_id                 = string
+      nsg_ids                   = optional(set(string), [])
+      is_cluster                = optional(bool, false)
+      is_dns_resolution_enabled = optional(bool, true)
+      defined_tags              = optional(map(string), {})
+      freeform_tags             = optional(map(string), {})
+    })), {})
+    opsi_private_endpoints = optional(map(object({
+      compartment_id      = optional(string)
+      display_name        = string
+      description         = optional(string)
+      vcn_id              = string
+      subnet_id           = string
+      nsg_ids             = optional(set(string), [])
+      is_used_for_rac_dbs = optional(bool, false)
+      defined_tags        = optional(map(string), {})
+      freeform_tags       = optional(map(string), {})
+    })), {})
+    databases = map(object({
+      compartment_id             = optional(string)
+      database_id                = string
+      database_type              = string
+      parent_database_key        = optional(string)
+      managed_database_id        = optional(string)
+      dbm_private_endpoint_id    = string
+      opsi_private_endpoint_id   = optional(string)
+      enable_operations_insights = optional(bool, false)
+      management_type            = optional(string, "ADVANCED")
+      service_name               = string
+      password_secret_id         = string
+      ssl_secret_id              = optional(string)
+      monitoring_user            = optional(string, "DBSNMP")
+      role                       = optional(string, "NORMAL")
+      protocol                   = optional(string, "TCP")
+      port                       = optional(number, 1521)
+      defined_tags               = optional(map(string), {})
+      freeform_tags              = optional(map(string), {})
+    }))
+  })
+
+  validation {
+    condition     = contains(["ENABLE", "DISABLE_TARGETS", "DISABLE_CDB"], upper(var.database_observability_configuration.operation_stage))
+    error_message = "operation_stage must be ENABLE, DISABLE_TARGETS, or DISABLE_CDB."
+  }
+
+  validation {
+    condition = (
+      length(var.database_observability_configuration.lifecycle_id) >= 8 &&
+      length(var.database_observability_configuration.lifecycle_id) <= 64 &&
+      can(regex("^[A-Za-z0-9][A-Za-z0-9_.-]+$", var.database_observability_configuration.lifecycle_id))
+    )
+    error_message = "lifecycle_id must be 8-64 characters and contain only letters, numbers, dots, underscores, and hyphens."
+  }
+
+  validation {
+    condition = alltrue([
+      for target in values(var.database_observability_configuration.databases) :
+      contains(["CDB", "PDB", "NON_CDB"], upper(target.database_type))
+    ])
+    error_message = "database_type must be CDB, PDB, or NON_CDB."
+  }
+
+  validation {
+    condition = alltrue([
+      for key, target in var.database_observability_configuration.databases :
+      upper(target.database_type) != "PDB" || (
+        try(trimspace(target.parent_database_key), "") != "" &&
+        contains(keys(var.database_observability_configuration.databases), target.parent_database_key) &&
+        upper(try(var.database_observability_configuration.databases[target.parent_database_key].database_type, "")) == "CDB" &&
+        upper(try(var.database_observability_configuration.databases[target.parent_database_key].management_type, "")) == "ADVANCED"
+      )
+    ])
+    error_message = "Every PDB must reference an ADVANCED CDB in the same databases map through parent_database_key."
+  }
+
+  validation {
+    condition = alltrue([
+      for target in values(var.database_observability_configuration.databases) :
+      upper(target.database_type) == "PDB" || try(trimspace(target.parent_database_key), "") == ""
+    ])
+    error_message = "Only PDB targets may set parent_database_key."
+  }
+
+  validation {
+    condition = (
+      upper(var.database_observability_configuration.operation_stage) != "DISABLE_CDB" ||
+      alltrue([
+        for target in values(var.database_observability_configuration.databases) :
+        upper(target.database_type) != "PDB" || try(trimspace(target.managed_database_id), "") != ""
+      ])
+    )
+    error_message = "DISABLE_CDB requires managed_database_id for every PDB so current DBM feature state can be read authoritatively."
+  }
+
+  validation {
+    condition = alltrue([
+      for target in values(var.database_observability_configuration.databases) :
+      trimspace(target.database_id) != "" &&
+      trimspace(target.dbm_private_endpoint_id) != "" &&
+      trimspace(target.service_name) != "" &&
+      trimspace(target.password_secret_id) != "" &&
+      trimspace(target.monitoring_user) != ""
+    ])
+    error_message = "Every database requires database_id, dbm_private_endpoint_id, service_name, password_secret_id, and monitoring_user."
+  }
+
+  validation {
+    condition = alltrue([
+      for target in values(var.database_observability_configuration.databases) :
+      !target.enable_operations_insights || try(trimspace(target.opsi_private_endpoint_id), "") != ""
+    ])
+    error_message = "enable_operations_insights=true requires opsi_private_endpoint_id."
+  }
+
+  validation {
+    condition = alltrue([
+      for target in values(var.database_observability_configuration.databases) :
+      contains(["BASIC", "ADVANCED"], upper(target.management_type))
+    ])
+    error_message = "management_type must be BASIC or ADVANCED."
+  }
+
+  validation {
+    condition = alltrue([
+      for target in values(var.database_observability_configuration.databases) :
+      contains(["NORMAL", "SYSDBA", "SYSOPER", "SYSASM"], upper(target.role))
+    ])
+    error_message = "role must be NORMAL, SYSDBA, SYSOPER, or SYSASM."
+  }
+
+  validation {
+    condition = alltrue([
+      for target in values(var.database_observability_configuration.databases) :
+      contains(["TCP", "TCPS"], upper(target.protocol)) &&
+      target.port >= 1 &&
+      target.port <= 65535 &&
+      (upper(target.protocol) != "TCPS" || try(trimspace(target.ssl_secret_id), "") != "")
+    ])
+    error_message = "protocol must be TCP or TCPS, port must be 1-65535, and TCPS requires ssl_secret_id."
+  }
+}
+
+variable "compartments_dependency" {
+  description = "Externally managed compartments keyed by Landing Zone reference."
+  type        = map(object({ id = string }))
+  default     = {}
+}
+
+variable "vcns_dependency" {
+  description = "Externally managed VCNs keyed by Landing Zone reference."
+  type        = map(object({ id = string }))
+  default     = {}
+}
+
+variable "subnets_dependency" {
+  description = "Externally managed subnets keyed by Landing Zone reference."
+  type        = map(object({ id = string }))
+  default     = {}
+}
+
+variable "network_security_groups_dependency" {
+  description = "Externally managed network security groups keyed by Landing Zone reference."
+  type        = map(object({ id = string }))
+  default     = {}
+}
+
+variable "databases_dependency" {
+  description = "Externally managed cloud databases and pluggable databases keyed by Landing Zone reference."
+  type        = map(object({ id = string }))
+  default     = {}
+}
+
+variable "managed_databases_dependency" {
+  description = "Database Management managed-database identities keyed by Landing Zone reference. Used for fail-closed CDB disable verification."
+  type        = map(object({ id = string }))
+  default     = {}
+}
+
+variable "vault_secrets_dependency" {
+  description = "Externally managed Vault secrets keyed by Landing Zone reference."
+  type        = map(object({ id = string }))
+  default     = {}
+}
+
+variable "dbm_private_endpoints_dependency" {
+  description = "Externally managed Database Management private endpoints keyed by Landing Zone reference."
+  type        = map(object({ id = string }))
+  default     = {}
+}
+
+variable "opsi_private_endpoints_dependency" {
+  description = "Externally managed Operations Insights private endpoints keyed by Landing Zone reference."
+  type        = map(object({ id = string }))
+  default     = {}
+}
+
+variable "enable_output" {
+  description = "Whether Terraform should expose module outputs."
+  type        = bool
+  default     = true
+}
+
+variable "module_name" {
+  description = "The module name used in Landing Zone ownership tags."
+  type        = string
+  default     = "database-observability"
+}


### PR DESCRIPTION
Closes #33.

## Summary

Adds a production-oriented `database-observability` module for OCI Base
Database Service and Exadata Database Service CDB, PDB, and non-CDB targets.

The module:

- enables/disables OCI Database Management with the provider's target-specific
  resources;
- optionally creates or consumes Database Management and Operations Insights
  private endpoints;
- optionally enables Operations Insights Database Insights;
- accepts literal OCIDs or Landing Zone dependency keys;
- accepts Vault secret references only;
- enforces a provider-observed, two-stage CDB/PDB disable workflow;
- includes Base Database and Exadata examples, JSON templates, JSON Schema,
  module specification, migration notes, outputs, and One-OE source fragments.

Autonomous Database and external database lifecycle APIs are intentionally out
of scope pending separate provider contracts and tests.

## Validation

- `terraform fmt -check -recursive database-observability`
- `terraform init -backend=false -input=false` and `terraform validate`:
  - `database-observability`
  - `database-observability/examples/base-database`
  - `database-observability/examples/exadata-database-service`
- JSON parsing and Draft 2020-12 schema validation
- focused module contract tests: 8 passed
- source project regression: 646 passed, 89.95% coverage
- path-aware security scan and contribution-commit gitleaks scan: clean

No credentials, populated OCIDs, Terraform state, plans, or populated variable
files are included.

## Production acceptance gates

This PR supplies code and local/static verification. A release still requires:

- Oracle Contributor Agreement verification for the sign-off identity;
- maintainer review and release/version decisions;
- an owner-approved OCI canary plan/apply;
- post-apply Database Management and Operations Insights collection evidence.
